### PR TITLE
CA-109476: Read rrd plugin timestamp as int64

### DIFF
--- a/rrdd/rrdd_server.ml
+++ b/rrdd/rrdd_server.ml
@@ -326,7 +326,7 @@ module Plugin = struct
 
 	(* The payload type that corresponds to the plugin output file format. *)
 	type payload = {
-		timestamp : int;
+		timestamp : int64;
 		datasources : (Rrd.ds_owner * Ds.ds) list;
 	}
 
@@ -414,7 +414,7 @@ module Plugin = struct
 			let open Rpc in
 			let rpc = Jsonrpc.of_string json in
 			let kvs = dict_of_rpc ~rpc in
-			let timestamp = int_of_rpc (List.assoc "timestamp" kvs) in
+			let timestamp = int64_of_rpc (List.assoc "timestamp" kvs) in
 			let datasource_rpcs = dict_of_rpc (List.assoc "datasources" kvs) in
 			{timestamp; datasources = List.map ds_of_rpc datasource_rpcs}
 		with _ -> log_backtrace (); raise Invalid_payload


### PR DESCRIPTION
It's written as an int64 by the plugin library. Also, a standard int
isn't big enough to hold a typical Unix epoch.

This value isn't actually used, rrdd just relies on it changing so
that the plugin payload's checksum changes even if the data source
values stay the same. However, it would be nice if it's correct in
case we do ever want to use it!

Imported from xen-api.git aa0489fafdb5b42bfdfe1836bf8311df629ce6a8
