### PR TITLE
CA-137766: Remove GC stats reporting

### DIFF
--- a/rrdd/rrdd_shared.ml
+++ b/rrdd/rrdd_shared.ml
@@ -31,8 +31,6 @@ let memory_targets_m = Mutex.create ()
 let cache_sr_uuid : string option ref = ref None
 let cache_sr_lock = Mutex.create ()
 
-let gc_debug = ref true
-
 let default_ssl_port = 443
 let https_port = ref default_ssl_port
 


### PR DESCRIPTION
This code erroneously reported rrdd's GC stats as xapi's. The code has
now been moved to xapi itself, which reports these and other stats to
rrdd via the plugin mechanism.
