### PR TITLE
CA-150826: Fix monitoring of xenopsd

### DIFF
--- a/rrdd/rrdd_stats.ml
+++ b/rrdd/rrdd_stats.ml
@@ -177,7 +177,7 @@ let print_stats_for ~program =
 
 let last_log = ref 0.
 let log_interval = 60.
-let programs_to_monitor = ["xcp-rrdd"; "xapi"; "xenopsd"]
+let programs_to_monitor = ["xcp-rrdd"; "xapi"; "xenopsd-xc"; "xenopsd-xenlight"]
 
 let print_stats () =
 	print_system_stats ();


### PR DESCRIPTION
Instead of monitoring the xenopsd process (which doesn't exist any more)
monitor xenopsd-xc and xenopsd-xenlight.
