### PR TITLE
CA-182722: Update RRDs only once per SR

### DIFF
--- a/rrdd/rrdd_monitor.ml
+++ b/rrdd/rrdd_monitor.ml
@@ -128,7 +128,9 @@ let update_rrds timestamp dss (uuid_domids : (string * int) list) paused_vms =
 				(*debug "Error: caught exception %s" (ExnHelper.string_of_exn e);*)
 				log_backtrace ()
 		in
-		let uuid_srs = List.filter_map (fun (ty, ds) -> match ty with SR x -> Some x | _ -> None) dss in
+		let uuid_srs =
+			List.filter_map (fun (ty, ds) -> match ty with SR x -> Some x | _ -> None) dss
+			|> List.setify in
 		List.iter do_sr uuid_srs;
 
 		let host_dss = List.filter_map (fun (ty, ds) -> match ty with | Host -> Some ds | _ -> None) dss in


### PR DESCRIPTION
Otherwise the time since last update will be calculated as zero and the
datasources will be clobbered since gauge datasource types are multiplied by
the interval and so the datasource becomes zero.

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>