### PR TITLE
CP-13995: Adding functions into xcp-rrdd for archiving of sr-level rrds

### DIFF
--- a/rrdd/rrdd_server.ml
+++ b/rrdd/rrdd_server.ml
@@ -25,6 +25,38 @@ open Rrdd_shared
 module D = Debug.Make(struct let name="rrdd_server" end)
 open D
 
+let sr_rrds_path _ ~(sr_uuid : string) : string =
+	Filename.concat sr_rrds_location (sr_uuid ^ ".gz")
+
+let archive_sr_rrd _ ~(sr_uuid : string) : unit =
+	if Mutex.try_lock mutex then begin
+		let srrds =
+			try
+				Hashtbl.fold (fun k v acc -> (k,v.rrd)::acc) sr_rrds []
+			with exn ->
+				Mutex.unlock mutex;
+				raise exn
+		in
+		Mutex.unlock mutex;
+		try
+			let rrd = List.assoc sr_uuid srrds in
+			archive_rrd ~uuid:sr_uuid ~rrd ()
+		with Not_found -> ()
+	end
+
+let get_sr_rrd ~sr_uuid =
+	let path = Filename.concat sr_rrds_location sr_uuid in
+	rrd_of_gzip path
+
+let push_sr_rrd _ ~(sr_uuid : string) : unit =
+	try
+		let rrd = get_sr_rrd ~sr_uuid in
+		debug "Pushing RRD for SR uuid=%s locally" sr_uuid;
+		Mutex.execute mutex (fun _ ->
+			Hashtbl.replace sr_rrds sr_uuid {rrd; dss=[]; domid=0}
+		)
+	with _ -> ()
+
 let has_vm_rrd _ ~(vm_uuid : string) =
 	Mutex.execute mutex (fun _ -> Hashtbl.mem vm_rrds vm_uuid)
 

--- a/rrdd/rrdd_shared.ml
+++ b/rrdd/rrdd_shared.ml
@@ -34,6 +34,8 @@ let cache_sr_lock = Mutex.create ()
 let default_ssl_port = 443
 let https_port = ref default_ssl_port
 
+let sr_rrds_location = Constants.rrd_location
+
 (** Pool secret. *)
 let get_pool_secret () =
 	try


### PR DESCRIPTION
This PR is just for review, It need to be merged into trunk-thin-lvhd-2 branch.