### PR TITLE
CA-197077: Handle there being no SR data sources.

### DIFF
--- a/rrdd/rrdd_server.ml
+++ b/rrdd/rrdd_server.ml
@@ -340,8 +340,10 @@ let forget_sr_ds _ ~(sr_uuid : string) ~(ds_name : string) : unit =
 
 let query_possible_sr_dss _ ~(sr_uuid : string) : Data_source.t list =
 	Mutex.execute mutex (fun () ->
-		let rrdi = Hashtbl.find sr_rrds sr_uuid in
-		query_possible_dss rrdi
+		try
+			let rrdi = Hashtbl.find sr_rrds sr_uuid in
+			query_possible_dss rrdi
+		with Not_found -> []
 	)
 
 let query_sr_ds _ ~(sr_uuid : string) ~(ds_name : string) : float =


### PR DESCRIPTION
We don't need this for the VM/host API calls as there's always
_some_ data sources for those objects, whereas for all SRs there
are currently none.

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>