### PR TITLE
CA-277850 increase loglevel to info for memfree

### DIFF
--- a/rrdd/xcp_rrdd.ml
+++ b/rrdd/xcp_rrdd.ml
@@ -159,7 +159,7 @@ module Meminfo = struct
         let client = Xs.get_client () in
         let meminfo_free_string = Xs.immediate client (fun xs -> Xs.read xs path) in
         let meminfo_free = Int64.of_string meminfo_free_string in
-        debug "memfree has changed to %Ld in domain %d" meminfo_free d;
+        info "memfree has changed to %Ld in domain %d" meminfo_free d;
         current_meminfofree_values := IntMap.add d meminfo_free !current_meminfofree_values
       with Xs_protocol.Enoent _hint ->
         debug "Couldn't read path %s; forgetting last known memfree value for domain %d" path d;

--- a/rrdd/xcp_rrdd.ml
+++ b/rrdd/xcp_rrdd.ml
@@ -152,7 +152,7 @@ module Meminfo = struct
   let fire_event_on_vm domid domains =
     let d = int_of_string domid in
     if not(IntMap.mem d domains)
-    then debug "Ignoring watch on shutdown domain %d" d
+    then info "Ignoring watch on shutdown domain %d" d
     else
       let path = meminfo_path d in
       try
@@ -162,7 +162,7 @@ module Meminfo = struct
         info "memfree has changed to %Ld in domain %d" meminfo_free d;
         current_meminfofree_values := IntMap.add d meminfo_free !current_meminfofree_values
       with Xs_protocol.Enoent _hint ->
-        debug "Couldn't read path %s; forgetting last known memfree value for domain %d" path d;
+        info "Couldn't read path %s; forgetting last known memfree value for domain %d" path d;
         current_meminfofree_values := IntMap.remove d !current_meminfofree_values
 
   let watch_fired _xc path domains _ =


### PR DESCRIPTION
CA-277850 (failure to receive updates about free memory) is hard to
reproduce. We need at least temporarily more logging. This commit can be
reversed, once the problem has been fixed.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>