### PR TITLE
CA-277850 Replace xenops library with ezxenstore

### DIFF
--- a/rrdd/jbuild
+++ b/rrdd/jbuild
@@ -52,7 +52,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
                xapi-stdext-std
                xapi-stdext-threads
                xapi-stdext-unix
-               xenops
+               ezxenstore
                xcp.network
                uuid))
   ))

--- a/xapi-rrdd.opam
+++ b/xapi-rrdd.opam
@@ -3,10 +3,11 @@ maintainer: "xen-api@lists.xen.org"
 build: [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 build-test: ["jbuilder" "runtest" "-p" name]
 depends: [
-  "jbuilder" {build & >= "1.0+beta10"}
   "astring"
+  "ezxenstore"
   "inotify"
   "io-page"
+  "jbuilder" {build & >= "1.0+beta10"}
   "mtime"
   "ounit" {test}
   "rpc"
@@ -20,7 +21,6 @@ depends: [
   "xapi-stdext-std"
   "xapi-stdext-threads"
   "xapi-stdext-unix"
-  "xapi-xenops"
 ]
 ocaml-version: [>= "4.02.0"]
 


### PR DESCRIPTION
This commit replaces the use of xapi-xenops with ezxenstore. The latter
provides a more recent implementation to watch xenstore events. This
requires some small changes as the API between the two is slightly
different.

We suspect that issue CA-277850 is caused by the outdated xenstore watch
implementation.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>