### PR TITLE
update and simplify interface using fd-send-recv >= 2.0.0

### DIFF
--- a/xapi-rrdd.opam
+++ b/xapi-rrdd.opam
@@ -23,4 +23,6 @@ depends: [
   "xapi-stdext-unix"
 ]
 ocaml-version: [>= "4.02.0"]
-
+conflicts: [
+    "fd-send-recv" {< "2.0.0"}
+]


### PR DESCRIPTION
This depends on xs-opam 4.1.0 being released and xapi-project/stdext#31 to be merged