### PR TITLE
Simplify PPX processing in jbuild file

### DIFF
--- a/rrdd/jbuild
+++ b/rrdd/jbuild
@@ -1,27 +1,9 @@
 (* -*- tuareg -*- *)
-#require "unix"
-
-let flags = function
-| [] -> ""
-| pkgs ->
-  let cmd = "ocamlfind ocamlc -verbose" ^ (
-    List.fold_left (fun acc pkg -> acc ^ " -package " ^ pkg) "" pkgs
-  ) in
-  let ic = Unix.open_process_in
-    (cmd ^ " | grep -oEe '-ppx (\"([^\"\\]|\\.)+\"|\\w+)'")
-  in
-  let rec go ic acc =
-    try go ic (acc ^ " " ^ input_line ic) with End_of_file -> close_in ic; acc
-  in
-  go ic ""
-
 let version =
   let ic = open_in "../VERSION" in
   let version = input_line ic in
   close_in ic;
   version
-
-let rewriters = ["ppx_deriving_rpc"]
 
 let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (rule
@@ -35,7 +17,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
   ((name rrdd_libs_internal)
    (wrapped false)
    (modules (:standard \ xcp_rrdd))
-   (flags (:standard -w -39 -bin-annot %s))
+   (flags (:standard -w -39))
    (libraries (astring
                gzip
                http-svr
@@ -55,17 +37,18 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
                ezxenstore
                xcp.network
                uuid))
+   (preprocess (pps (ppx_deriving_rpc)))
   ))
 
 (executable
   ((name xcp_rrdd)
    (public_name xcp-rrdd)
    (package xapi-rrdd)
-   (flags (:standard -bin-annot %s))
+   (flags (:standard))
    (modules (xcp_rrdd))
    (libraries (http-svr
                rrdd_libs_internal
                xapi-backtrace
                xcp))
   ))
-|} version (flags rewriters) (flags rewriters)
+|} version

--- a/test/jbuild
+++ b/test/jbuild
@@ -1,33 +1,14 @@
-(* -*- tuareg -*- *)
-#require "unix"
 
-let flags = function
-| [] -> ""
-| pkgs ->
-  let cmd = "ocamlfind ocamlc -verbose" ^ (
-    List.fold_left (fun acc pkg -> acc ^ " -package " ^ pkg) "" pkgs
-  ) in
-  let ic = Unix.open_process_in
-    (cmd ^ " | grep -oEe '-ppx (\"([^\"\\]|\\.)+\"|\\w+)'")
-  in
-  let rec go ic acc =
-    try go ic (acc ^ " " ^ input_line ic) with End_of_file -> close_in ic; acc
-  in
-  go ic ""
-
-let rewriters = ["ppx_deriving_rpc"]
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (executable
   ((name test_rrdd_monitor)
-   (flags (:standard -bin-annot %s))
+   (flags (:standard))
    (libraries (oUnit
                rrdd_libs_internal
                ))
+   (preprocess (pps (ppx_deriving_rpc)))
   ))
 
 (alias
  ((name    runtest)
   (deps    (test_rrdd_monitor.exe))
   (action  (run ${<}))))
-|} (flags rewriters)


### PR DESCRIPTION
We take advantage of improved PPX capabilities in Jbuilder/Dune. In
addition, we no longer generate .annot files because Merlin used .cmt
files.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>