### PR TITLE
CP-30614: Export Memory stats to filesystem

### DIFF
--- a/rrdd/rrdd_monitor.ml
+++ b/rrdd/rrdd_monitor.ml
@@ -50,8 +50,8 @@ let merge_new_dss rrd dss =
  * archive the RRD. *)
 let update_rrds timestamp dss (uuid_domids : (string * int) list) paused_vms =
   (* Here we do the synchronising between the dom0 view of the world
-     		 and our Hashtbl. By the end of this execute block, the Hashtbl
-     		 correctly represents the world *)
+   * and our Hashtbl. By the end of this execute block, the Hashtbl
+   * correctly represents the world *)
   let execute = Xapi_stdext_threads.Threadext.Mutex.execute in
   execute mutex (fun _ ->
       let out_of_date, by_how_much =
@@ -71,11 +71,11 @@ let update_rrds timestamp dss (uuid_domids : (string * int) list) paused_vms =
               let rrd = merge_new_dss rrdi.rrd dss in
               Hashtbl.replace vm_rrds vm_uuid {rrd; dss; domid};
               (* CA-34383:
-                 						 * Memory updates from paused domains serve no useful purpose.
-                 						 * During a migrate such updates can also cause undesirable
-                 						 * discontinuities in the observed value of memory_actual.
-                 						 * Hence, we ignore changes from paused domains:
-                 						 *)
+               * Memory updates from paused domains serve no useful purpose.
+               * During a migrate such updates can also cause undesirable
+               * discontinuities in the observed value of memory_actual.
+               * Hence, we ignore changes from paused domains:
+               *)
               if not (List.mem vm_uuid paused_vms) then (
                 Rrd.ds_update_named rrd timestamp ~new_domid:(domid <> rrdi.domid)
                   (List.map (fun ds -> (ds.ds_name, (ds.ds_value, ds.ds_pdp_transform_function))) dss);

--- a/rrdd/rrdd_server.ml
+++ b/rrdd/rrdd_server.ml
@@ -135,7 +135,7 @@ module Deprecated = struct
     let pool_secret = get_pool_secret () in
     let uri = Rrdd_libs.Constants.get_host_rrd_uri in
     (* Add in "dbsync = true" to the query to make sure the master
-       		 * doesn't try to redirect here! *)
+     * doesn't try to redirect here! *)
     let uri = uri ^ "?uuid=" ^ uuid ^ "&dbsync=true" in
     let request =
       Http.Request.make ~user_agent:Rrdd_libs.Constants.rrdd_user_agent
@@ -156,9 +156,9 @@ module Deprecated = struct
 
   (* DEPRECATED *)
   (* This used to be called from dbsync in two cases:
-     	 * 1. For the local host after a xapi restart or host restart.
-     	 * 2. For running VMs after a xapi restart.
-     	 * It is now only used to load the host's RRD after xapi restart. *)
+   * 1. For the local host after a xapi restart or host restart.
+   * 2. For running VMs after a xapi restart.
+   * It is now only used to load the host's RRD after xapi restart. *)
   let load_rrd (uuid : string) (timescale : int) (master_address : string option) : unit =
     try
       let rrd =
@@ -377,7 +377,7 @@ module Plugin = struct
   let header = "DATASOURCES\n"
 
   (* The function that tells the plugin what to write at the top of its output
-     	 * file. *)
+   * file. *)
   let get_header () : string = header
 
   (* The function that a plugin can use to determine which file to write to. *)
@@ -403,20 +403,20 @@ module Plugin = struct
     (* A type to represent a registered plugin. *)
 
     (* 11 October 2016
-       		 * This module needs a re-write when the next major addition comes
-       		 * along :
-       		 * - it would be convenient, not to pass the uid in addition to the
-       		 *   plugin around to facilitate error reporting
-       		 * - the back-off mechanism needs to be better encapsulated. In the
-       		 *   ideal case, we can use a wrap() function that turns a reader
-       		 *   that can fail into one that backs off in the presence of errors
-       		 *   and retries.
-       		 * - The error reporting could be moved out of get_payload to the
-       		 *   caller.
-       		 * - The lock-protected hash table could be made more abstract such
-       		 *   that locking is not spread over the module.
-       		 * - Can the code for backwards compatibility be expunged?
-       		 *)
+     * This module needs a re-write when the next major addition comes
+     * along :
+     * - it would be convenient, not to pass the uid in addition to the
+     *   plugin around to facilitate error reporting
+     * - the back-off mechanism needs to be better encapsulated. In the
+     *   ideal case, we can use a wrap() function that turns a reader
+     *   that can fail into one that backs off in the presence of errors
+     *   and retries.
+     * - The error reporting could be moved out of get_payload to the
+     *   caller.
+     * - The lock-protected hash table could be made more abstract such
+     *   that locking is not spread over the module.
+     * - Can the code for backwards compatibility be expunged?
+     *)
 
     type plugin = {
       info: P.info;
@@ -426,7 +426,7 @@ module Plugin = struct
     }
 
     (* A map storing currently registered plugins, and any data required to
-       		 * process the plugins. *)
+     * process the plugins. *)
     let registered: (P.uid, plugin) Hashtbl.t = Hashtbl.create 20
 
     (* The mutex that protects the list of registered plugins against race
@@ -488,8 +488,8 @@ module Plugin = struct
         end
 
     (* Returns the number of seconds until the next reading phase for the
-       		 * sampling frequency given at registration by the plugin with the specified
-       		 * unique ID. If the plugin is not registered, -1 is returned. *)
+     * sampling frequency given at registration by the plugin with the specified
+     * unique ID. If the plugin is not registered, -1 is returned. *)
     let next_reading (uid: P.uid) : float =
       let open Rrdd_shared in
       if Mutex.execute registered_m (fun _ -> Hashtbl.mem registered uid)
@@ -503,7 +503,7 @@ module Plugin = struct
       | Rrd_interface.V2 -> Rrd_protocol_v2.protocol
 
     (* The function registers a plugin, and returns the number of seconds until
-       		 * the next reading phase for the specified sampling frequency. *)
+     * the next reading phase for the specified sampling frequency. *)
     let register (uid: P.uid)  (info: P.info)
         (protocol: Rrd_interface.plugin_protocol)
       : float =
@@ -520,7 +520,7 @@ module Plugin = struct
       next_reading uid
 
     (* The function deregisters a plugin. After this call, the framework will
-       		 * process its output at most once more. *)
+     * process its output at most once more. *)
     let deregister (uid: P.uid) : unit =
       Mutex.execute registered_m
         (fun _ ->

--- a/rrdd/rrdd_stats.ml
+++ b/rrdd/rrdd_stats.ml
@@ -142,7 +142,7 @@ let pidof ?(pid_dir="/var/run") program =
     let words = Astring.String.fields ~empty:false out in
     let maybe_parse_int acc i = try (int_of_string i) :: acc with Failure _ -> acc in
     List.fold_left maybe_parse_int [] words
-  with 
+  with
   | Unix.Unix_error (Unix.ENOENT, _, _)
   | Unix.Unix_error (Unix.EACCES, _, _) -> []
 

--- a/rrdd/xcp_rrdd.ml
+++ b/rrdd/xcp_rrdd.ml
@@ -260,7 +260,7 @@ let update_pcpus xc =
     ) ([], 0) newinfos in
   let sum_array = Array.fold_left (fun acc v -> Int64.add acc v) 0L newinfos in
   let avg_array = Int64.to_float sum_array /. (float_of_int len_newinfos) in
-  let avgcpu_ds = (Host, ds_make 
+  let avgcpu_ds = (Host, ds_make
                      ~name:"cpu_avg" ~units:"(fraction)"
                      ~description:"Average physical cpu usage"
                      ~value:(Rrd.VT_Float (avg_array /. 1.0e9)) ~min:0.0 ~max:1.0
@@ -554,7 +554,7 @@ module Discover: DISCOVER = struct
   let directory = Rrdd_server.Plugin.base_path
 
   (** [is_valid f] is true, if [f] is a filename for an RRD file.
-      	 *  Currently we only ignore *.tmp files *)
+   *  Currently we only ignore *.tmp files *)
   let is_valid file =
     not @@ Filename.check_suffix file ".tmp"
 
@@ -566,10 +566,10 @@ module Discover: DISCOVER = struct
       |> String.concat ","
 
   (* [register file] is called when we found a new file in the watched
-     	 * directory. We do not verify that this is a proper RRD file.
-     	 * [file] is not a complete path but just the basename of the file.
-     	 * This corresponds to how the file is used by the Plugin module,
-     	 * *)
+   * directory. We do not verify that this is a proper RRD file.
+   * [file] is not a complete path but just the basename of the file.
+   * This corresponds to how the file is used by the Plugin module,
+   * *)
   let register file =
     info "RRD plugin %s discovered - registering it" file;
     let info  = Rrd.Five_Seconds in
@@ -578,14 +578,14 @@ module Discover: DISCOVER = struct
     |> ignore (* seconds until next reading phase *)
 
   (* [deregister file] is called when a file is removed from the watched
-     	 * directory *)
+   * directory *)
   let deregister file =
     info "RRD plugin - de-registering %s" file;
     Rrdd_server.Plugin.Local.deregister file
 
   (* Here we dispatch over all events that we receive. Note that
-     	 * [Inotify.read] blocks until an event becomes available. Hence, this
-     	 * code needs to run in its own thread. *)
+   * [Inotify.read] blocks until an event becomes available. Hence, this
+   * code needs to run in its own thread. *)
   let watch dir =
     let fd          = Inotify.create () in
     let selectors   =
@@ -694,9 +694,9 @@ let _ =
 
   debug "Starting the HTTP server ..";
   (* Eventually we should switch over to xcp_service to declare our services,
-     	   but since it doesn't support HTTP GET and PUT we keep the old code for now.
-     	   We must avoid creating the Unix domain socket twice, so we only call
-     	   Xcp_service.serve_forever if we are actually using the message-switch. *)
+   * but since it doesn't support HTTP GET and PUT we keep the old code for now.
+   * We must avoid creating the Unix domain socket twice, so we only call
+   * Xcp_service.serve_forever if we are actually using the message-switch. *)
   let (_: Thread.t) =
     Thread.create (fun () ->
         if !Xcp_client.use_switch then begin

--- a/rrdd/xcp_rrdd.ml
+++ b/rrdd/xcp_rrdd.ml
@@ -100,7 +100,6 @@ let start (xmlrpc_path, http_fwd_path) process =
 (* Monitoring code --- START. *)
 
 open Xapi_stdext_monadic
-open Xapi_stdext_std.Listext
 open Xapi_stdext_threads.Threadext
 module Hashtblext = Xapi_stdext_std.Hashtblext
 open Network_stats
@@ -403,7 +402,7 @@ let read_cache_stats timestamp =
     let assoc_list =
       cache_stats_out
       |> Astring.String.cuts ~sep:"\n"
-      |> List.filter_map (fun line -> Astring.String.cut ~sep:"=" line)
+      |> Xapi_stdext_std.Listext.List.filter_map (fun line -> Astring.String.cut ~sep:"=" line)
     in
     (*debug "assoc_list: [%s]" (String.concat ";" (List.map (fun (a,b) -> Printf.sprintf "%s=%s" a b) assoc_list));*)
     {time = timestamp;

--- a/rrdd/xcp_rrdd.ml
+++ b/rrdd/xcp_rrdd.ml
@@ -305,10 +305,10 @@ let update_memory _xc doms =
     ) [] doms
 
 let update_loadavg () =
-  Host, ds_make ~name:"loadavg" ~units:"(fraction)"
+  [(Host, ds_make ~name:"loadavg" ~units:"(fraction)"
     ~description:"Domain0 loadavg"
     ~value:(Rrd.VT_Float (Rrdd_common.loadavg ()))
-    ~ty:Rrd.Gauge ~default:true ()
+    ~ty:Rrd.Gauge ~default:true ())]
 
 (*****************************************************)
 (* network related code                              *)
@@ -489,7 +489,7 @@ let generate_all_dom0_stats xc timestamp domains uuid_domids =
       handle_exn "update_netdev" (fun _ -> update_netdev domains) [];
       handle_exn "cache_stats" (fun _ -> read_cache_stats timestamp) [];
       handle_exn "update_pcpus" (fun _-> update_pcpus xc) [];
-      handle_exn "update_loadavg" (fun _ -> [update_loadavg ()]) [];
+      handle_exn "update_loadavg" (fun _ -> update_loadavg ()) [];
       handle_exn "update_memory" (fun _ -> update_memory xc domains) []
     ]
 

--- a/rrdd/xcp_rrdd.ml
+++ b/rrdd/xcp_rrdd.ml
@@ -662,10 +662,10 @@ let doc = String.concat "\n" [
 
 (** we need to make sure we call exit on fatal signals to
  * make sure profiling data is dumped
-*)
-let stop signal =
+ *)
+let stop err signal =
   debug "caught signal %d" signal;
-  exit 1
+  exit err
 
 (* Entry point. *)
 let _ =
@@ -673,9 +673,10 @@ let _ =
   Rrdd_bindings.Rrd_daemon.bind (); (* bind PPX-generated server calls to implementation of API *)
 
   (* Prevent shutdown due to sigpipe interrupt. This protects against
-     	 * potential stunnel crashes. *)
+   * potential stunnel crashes. *)
   Sys.set_signal Sys.sigpipe Sys.Signal_ignore;
-  Sys.set_signal Sys.sigterm (Sys.Signal_handle stop);
+  Sys.set_signal Sys.sigterm (Sys.Signal_handle (stop 1));
+  Sys.set_signal Sys.sigint (Sys.Signal_handle (stop 0));
 
   (* Enable the new logging library. *)
   Debug.set_facility Syslog.Local5;

--- a/rrdd/xcp_rrdd.ml
+++ b/rrdd/xcp_rrdd.ml
@@ -674,7 +674,7 @@ let stats_to_write = [
 let configure_writers () =
   List.map
     (fun name ->
-      let path = Rrdd_server.Plugin.get_path name in
+      let path = Rrdd_server.Plugin.get_path ("xcp-rrdd-" ^ name) in
       ignore (Xapi_stdext_unix.Unixext.mkdir_safe (Filename.dirname path) 0o644);
       let writer = snd (Rrd_writer.FileWriter.create
         {path; shared_page_count = 1}

--- a/rrdd/xcp_rrdd.ml
+++ b/rrdd/xcp_rrdd.ml
@@ -482,18 +482,11 @@ let domain_snapshot xc =
   timestamp, domains, uuid_domids, vcpus, my_paused_domain_uuids
 
 let generate_all_dom0_stats xc timestamp domains uuid_domids vcpus =
-  let vifs =
-    try update_netdev domains
-    with e ->
-      debug "Exception in update_netdev(). Defaulting value for vifs/pifs: %s"
-        (Printexc.to_string e);
-      []
-  in
   List.concat [
       handle_exn "ha_stats" (fun _ -> Rrdd_ha_stats.all ()) [];
       handle_exn "read_mem_metrics" (fun _ -> read_mem_metrics xc) [];
       vcpus;
-      vifs;
+      handle_exn "update_netdev" (fun _ -> update_netdev domains) [];
       handle_exn "cache_stats" (fun _ -> read_cache_stats timestamp) [];
       handle_exn "update_pcpus" (fun _-> update_pcpus xc) [];
       handle_exn "update_loadavg" (fun _ -> [update_loadavg ()]) [];

--- a/rrdd/xcp_rrdd.ml
+++ b/rrdd/xcp_rrdd.ml
@@ -667,7 +667,8 @@ let doc = String.concat "\n" [
 
 (** write memory stats to the filesystem so they can be propagated to xapi *)
 let stats_to_write = [
-  (*"update_memory"*)
+  "update_memory";
+  "read_mem_metrics"
 ]
 
 let configure_writers () =


### PR DESCRIPTION
This will allow xapi to read memory stats from the filesystem instead of depending directly on Xenctrl libs