### PR TITLE
Revert merge psafont/CA-30614

### DIFF
--- a/lib/stats.ml
+++ b/lib/stats.ml
@@ -22,7 +22,7 @@ module Normal_population = struct
 
   let empty = { sigma_x = 0.; sigma_xx = 0.; n = 0 }
 
-  let sample (p: t) (x: float) : t =
+  let sample (p: t) (x: float) : t = 
     { sigma_x = p.sigma_x +. x;
       sigma_xx = p.sigma_xx +. x *. x;
       n = p.n + 1 }
@@ -30,10 +30,10 @@ module Normal_population = struct
   exception Unknown
 
   let mean (p: t) : float = p.sigma_x /. (float_of_int p.n)
-  let sd (p: t) : float =
-    if p.n = 0
+  let sd (p: t) : float = 
+    if p.n = 0 
     then raise Unknown
-    else
+    else 
       let n = float_of_int p.n in
       sqrt (n *. p.sigma_xx -. p.sigma_x *. p.sigma_x) /. n
 end
@@ -43,7 +43,7 @@ end
    number should never be proportional to the number of VMs, VIFs etc!
 
    Since these are used for timing data, which is better approximated by a
-   lognormal distribution than a normal one, we take care to apply the
+   lognormal distribution than a normal one, we take care to apply the 
    lognormal transformations here.
 *)
 
@@ -64,28 +64,28 @@ end
 let timings : (string, Normal_population.t) Hashtbl.t = Hashtbl.create 10
 let timings_m = Mutex.create ()
 
-let mean (p: Normal_population.t) =
+let mean (p: Normal_population.t) = 
   let sigma = Normal_population.sd p in
   let mu = Normal_population.mean p in
   exp (mu +. sigma *. sigma /. 2.)
 
-let sd (p: Normal_population.t) =
+let sd (p: Normal_population.t) = 
   let sigma = Normal_population.sd p in
   let mu = Normal_population.mean p in
   let v = (exp(sigma *. sigma) -. 1.) *. (exp (2. *. mu +. sigma *. sigma)) in
   sqrt v
 
-let string_of (p: Normal_population.t) =
+let string_of (p: Normal_population.t) = 
   Printf.sprintf "%f [sd = %f]" (mean p) (sd p)
 
-let sample (name: string) (x: float) : unit =
+let sample (name: string) (x: float) : unit = 
   (* Use the lognormal distribution: *)
   let x' = log x in
   Mutex.execute timings_m
     (fun () ->
-       let p =
-         if Hashtbl.mem timings name
-         then Hashtbl.find timings name
+       let p = 
+         if Hashtbl.mem timings name 
+         then Hashtbl.find timings name 
          else Normal_population.empty in
        let p' = Normal_population.sample p x' in
        Hashtbl.replace timings name p';
@@ -98,7 +98,7 @@ let sample (name: string) (x: float) : unit =
 *)
 
 (** Helper function to time a specific thing *)
-let time_this (name: string) f =
+let time_this (name: string) f = 
   let start_time = Unix.gettimeofday () in
   let endfn () =
     try
@@ -111,11 +111,11 @@ let time_this (name: string) f =
     let result = f () in
     endfn ();
     result
-  with e ->
+  with e -> 
     endfn ();
     raise e
 
-let summarise () =
+let summarise () = 
   Mutex.execute timings_m
     (fun () ->
        Hashtbl.fold (fun k v acc -> (k, string_of v) :: acc) timings []
@@ -132,15 +132,16 @@ let dbstats_write_dbcalls : (string,int) Hashtbl.t = Hashtbl.create 100
 let dbstats_create_dbcalls : (string,int) Hashtbl.t = Hashtbl.create 100
 let dbstats_drop_dbcalls : (string,int) Hashtbl.t = Hashtbl.create 100
 let dbstats_task : (string,(string * dbcallty) list) Hashtbl.t = Hashtbl.create 100
+(* let dbstats_taskthreads : (string, int list) Hashtbl.t = Hashtbl.create 100*)
 let dbstats_threads : (int, (string * dbcallty) list) Hashtbl.t = Hashtbl.create 100
 
 let log_stats = ref false
 
-let log_db_call task_opt dbcall ty =
+let log_db_call task_opt dbcall ty = 
   if not !log_stats then () else
     Mutex.execute dbstats_m (fun () ->
-        let hashtbl = match ty with
-          | Read -> dbstats_read_dbcalls
+        let hashtbl = match ty with 
+          | Read -> dbstats_read_dbcalls 
           | Write -> dbstats_write_dbcalls
           | Create -> dbstats_create_dbcalls
           | Drop -> dbstats_drop_dbcalls
@@ -148,7 +149,7 @@ let log_db_call task_opt dbcall ty =
         Hashtbl.replace hashtbl dbcall (1 + (try Hashtbl.find hashtbl dbcall with _ -> 0));
         let threadid = Thread.id (Thread.self ()) in
         Hashtbl.replace dbstats_threads threadid ((dbcall,ty)::(try Hashtbl.find dbstats_threads threadid with _ -> []));
-        match task_opt with
+        match task_opt with 
         |	Some task ->
           Hashtbl.replace dbstats_task task ((dbcall,ty)::(try Hashtbl.find dbstats_task task with _ -> []))
         | None -> ()
@@ -172,4 +173,10 @@ let summarise_db_calls () =
        summarise_table dbstats_drop_dbcalls,
        Hashtbl.fold (fun k v acc -> (k,List.map (fun (dbcall,ty) -> (string_of_ty ty,dbcall)) (List.rev v))::acc) dbstats_task [],
        List.sort (fun (a,_) (b,_) -> compare a b) (Hashtbl.fold (fun k v acc -> (k,List.map (fun (dbcall,ty) -> (string_of_ty ty,dbcall)) (List.rev v))::acc) dbstats_threads [])))
+
+
+
+
+
+
 

--- a/rrdd/rrdd_monitor.ml
+++ b/rrdd/rrdd_monitor.ml
@@ -50,8 +50,8 @@ let merge_new_dss rrd dss =
  * archive the RRD. *)
 let update_rrds timestamp dss (uuid_domids : (string * int) list) paused_vms =
   (* Here we do the synchronising between the dom0 view of the world
-   * and our Hashtbl. By the end of this execute block, the Hashtbl
-   * correctly represents the world *)
+     		 and our Hashtbl. By the end of this execute block, the Hashtbl
+     		 correctly represents the world *)
   let execute = Xapi_stdext_threads.Threadext.Mutex.execute in
   execute mutex (fun _ ->
       let out_of_date, by_how_much =
@@ -71,11 +71,11 @@ let update_rrds timestamp dss (uuid_domids : (string * int) list) paused_vms =
               let rrd = merge_new_dss rrdi.rrd dss in
               Hashtbl.replace vm_rrds vm_uuid {rrd; dss; domid};
               (* CA-34383:
-               * Memory updates from paused domains serve no useful purpose.
-               * During a migrate such updates can also cause undesirable
-               * discontinuities in the observed value of memory_actual.
-               * Hence, we ignore changes from paused domains:
-               *)
+                 						 * Memory updates from paused domains serve no useful purpose.
+                 						 * During a migrate such updates can also cause undesirable
+                 						 * discontinuities in the observed value of memory_actual.
+                 						 * Hence, we ignore changes from paused domains:
+                 						 *)
               if not (List.mem vm_uuid paused_vms) then (
                 Rrd.ds_update_named rrd timestamp ~new_domid:(domid <> rrdi.domid)
                   (List.map (fun ds -> (ds.ds_name, (ds.ds_value, ds.ds_pdp_transform_function))) dss);

--- a/rrdd/rrdd_server.ml
+++ b/rrdd/rrdd_server.ml
@@ -135,7 +135,7 @@ module Deprecated = struct
     let pool_secret = get_pool_secret () in
     let uri = Rrdd_libs.Constants.get_host_rrd_uri in
     (* Add in "dbsync = true" to the query to make sure the master
-     * doesn't try to redirect here! *)
+       		 * doesn't try to redirect here! *)
     let uri = uri ^ "?uuid=" ^ uuid ^ "&dbsync=true" in
     let request =
       Http.Request.make ~user_agent:Rrdd_libs.Constants.rrdd_user_agent
@@ -156,9 +156,9 @@ module Deprecated = struct
 
   (* DEPRECATED *)
   (* This used to be called from dbsync in two cases:
-   * 1. For the local host after a xapi restart or host restart.
-   * 2. For running VMs after a xapi restart.
-   * It is now only used to load the host's RRD after xapi restart. *)
+     	 * 1. For the local host after a xapi restart or host restart.
+     	 * 2. For running VMs after a xapi restart.
+     	 * It is now only used to load the host's RRD after xapi restart. *)
   let load_rrd (uuid : string) (timescale : int) (master_address : string option) : unit =
     try
       let rrd =
@@ -377,7 +377,7 @@ module Plugin = struct
   let header = "DATASOURCES\n"
 
   (* The function that tells the plugin what to write at the top of its output
-   * file. *)
+     	 * file. *)
   let get_header () : string = header
 
   (* The function that a plugin can use to determine which file to write to. *)
@@ -403,20 +403,20 @@ module Plugin = struct
     (* A type to represent a registered plugin. *)
 
     (* 11 October 2016
-     * This module needs a re-write when the next major addition comes
-     * along :
-     * - it would be convenient, not to pass the uid in addition to the
-     *   plugin around to facilitate error reporting
-     * - the back-off mechanism needs to be better encapsulated. In the
-     *   ideal case, we can use a wrap() function that turns a reader
-     *   that can fail into one that backs off in the presence of errors
-     *   and retries.
-     * - The error reporting could be moved out of get_payload to the
-     *   caller.
-     * - The lock-protected hash table could be made more abstract such
-     *   that locking is not spread over the module.
-     * - Can the code for backwards compatibility be expunged?
-     *)
+       		 * This module needs a re-write when the next major addition comes
+       		 * along :
+       		 * - it would be convenient, not to pass the uid in addition to the
+       		 *   plugin around to facilitate error reporting
+       		 * - the back-off mechanism needs to be better encapsulated. In the
+       		 *   ideal case, we can use a wrap() function that turns a reader
+       		 *   that can fail into one that backs off in the presence of errors
+       		 *   and retries.
+       		 * - The error reporting could be moved out of get_payload to the
+       		 *   caller.
+       		 * - The lock-protected hash table could be made more abstract such
+       		 *   that locking is not spread over the module.
+       		 * - Can the code for backwards compatibility be expunged?
+       		 *)
 
     type plugin = {
       info: P.info;
@@ -426,7 +426,7 @@ module Plugin = struct
     }
 
     (* A map storing currently registered plugins, and any data required to
-     * process the plugins. *)
+       		 * process the plugins. *)
     let registered: (P.uid, plugin) Hashtbl.t = Hashtbl.create 20
 
     (* The mutex that protects the list of registered plugins against race
@@ -488,8 +488,8 @@ module Plugin = struct
         end
 
     (* Returns the number of seconds until the next reading phase for the
-     * sampling frequency given at registration by the plugin with the specified
-     * unique ID. If the plugin is not registered, -1 is returned. *)
+       		 * sampling frequency given at registration by the plugin with the specified
+       		 * unique ID. If the plugin is not registered, -1 is returned. *)
     let next_reading (uid: P.uid) : float =
       let open Rrdd_shared in
       if Mutex.execute registered_m (fun _ -> Hashtbl.mem registered uid)
@@ -503,7 +503,7 @@ module Plugin = struct
       | Rrd_interface.V2 -> Rrd_protocol_v2.protocol
 
     (* The function registers a plugin, and returns the number of seconds until
-     * the next reading phase for the specified sampling frequency. *)
+       		 * the next reading phase for the specified sampling frequency. *)
     let register (uid: P.uid)  (info: P.info)
         (protocol: Rrd_interface.plugin_protocol)
       : float =
@@ -520,7 +520,7 @@ module Plugin = struct
       next_reading uid
 
     (* The function deregisters a plugin. After this call, the framework will
-     * process its output at most once more. *)
+       		 * process its output at most once more. *)
     let deregister (uid: P.uid) : unit =
       Mutex.execute registered_m
         (fun _ ->

--- a/rrdd/rrdd_stats.ml
+++ b/rrdd/rrdd_stats.ml
@@ -142,7 +142,7 @@ let pidof ?(pid_dir="/var/run") program =
     let words = Astring.String.fields ~empty:false out in
     let maybe_parse_int acc i = try (int_of_string i) :: acc with Failure _ -> acc in
     List.fold_left maybe_parse_int [] words
-  with
+  with 
   | Unix.Unix_error (Unix.ENOENT, _, _)
   | Unix.Unix_error (Unix.EACCES, _, _) -> []
 


### PR DESCRIPTION
This reverts the commits below:

89e2eac9 2019-03-13 CP-30614: Do not register self-written files
badc7aa9 2019-03-13 maintenance: remove all Opens from xcp_rrdd
2176dc40 2019-03-13 maintenance: code reordering
6a574ec8 2019-03-13 CP-30614: Rename written DSS files
e6405ea0 2019-03-13 CP-30614: prefix files for easier identification
df51db12 2019-03-13 CP-30614: Write files for memory stats
3faf2e28 2019-03-13 CP-30614: Incorporate RRD filewriters
f482edc7 2019-03-13 maintenance: prepare for cleanup on sigint
a1848612 2019-03-13 maintenance: do not open Listext
88de8dd3 2019-03-13 CP-30614: decouple stats generation from consolidation
b970f84a 2019-03-13 maintenance: separate dds function naming from applicat
ca87ee8d 2019-03-13 maintenance: make update_loadavg to return a list of ds
efaea465 2019-03-13 maintenance: Separate uuid calculation from vgpu dss
846a518b 2019-03-13 maintenance: reuse exception handler for vifs
9d245ecb 2019-03-13 CP-30614: Prepare for file-writing stats within the mon
f54f51a4 2019-03-13 maintenance: whitespace and comment tidying

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>