### PR TITLE
CA-322045: Enable fastpath for xcp-rrdd http server

### DIFF
--- a/rrdd/xcp_rrdd.ml
+++ b/rrdd/xcp_rrdd.ml
@@ -62,6 +62,7 @@ let accept_forever sock f =
 (* Bind server to the file descriptor. *)
 let start (xmlrpc_path, http_fwd_path) process =
   let server = Http_svr.Server.empty () in
+  Http_svr.Server.enable_fastpath server;
   let open Rrdd_http_handler in
   Http_svr.Server.add_handler server Http.Post "/" (Http_svr.BufIO (xmlrpc_handler process));
   Http_svr.Server.add_handler server Http.Get Rrdd_libs.Constants.get_vm_rrd_uri (Http_svr.FdIO get_vm_rrd_handler);


### PR DESCRIPTION
Discovered while investigating CA-322045 (xcp-rrdd takes a long time to finish backing up the rrds during a toolstack restart).

XAPI already enables this by default, so it should be safe to enable it
for xcp-rrdd too.

By default without fastpath Http_svr reads the http headers
byte-by-byte.
With fastpath it reads the minimum HTTP header request size, and then 4
byte at a time until end of headers (it still needs to stop exactly
where the headers finish so that file descriptor passing would work).

It might be possible to improve this further, since AFAICT xcp-rrdd does
not use file descriptor passing on its main socket, but perhaps
we could do that by switching to message-switch or cohttp in the future.

I've confirmed with `strace` that indeed xcp-rrdd reads requests more efficiently now:
```
[pid 14421] read(26, "POST /var/lib/xcp/", 18) = 18
[pid 14421] read(26, "xcp-", 4)         = 4
[pid 14421] read(26, "rrdd", 4)         = 4
[pid 14421] read(26, " HTT", 4)         = 4
[pid 14421] read(26, "P/1.", 4)         = 4
[pid 14421] read(26, "1\r\nc", 4)       = 4
[pid 14421] read(26, "onte", 4)         = 4
[pid 14421] read(26, "nt-l", 4)         = 4
[pid 14421] read(26, "engt", 4)         = 4
[pid 14421] read(26, "h: 2", 4)         = 4
[pid 14421] read(26, "21\r\n", 4)       = 4
[pid 14421] read(26, "ho", 2)           = 2
[pid 14421] read(26, "st: ", 4)         = 4
[pid 14421] read(26, "loca", 4)         = 4
[pid 14421] read(26, "lhos", 4)         = 4
[pid 14421] read(26, "t\r\nu", 4)       = 4
[pid 14421] read(26, "ser-", 4)         = 4
[pid 14421] read(26, "agen", 4)         = 4
[pid 14421] read(26, "t: /", 4)         = 4
[pid 14421] read(26, "opt/", 4)         = 4
[pid 14421] read(26, "xens", 4)         = 4
[pid 14421] read(26, "ourc", 4)         = 4
[pid 14421] read(26, "e/li", 4)         = 4
[pid 14421] read(26, "bexe", 4)         = 4
[pid 14421] read(26, "c/xc", 4)         = 4
[pid 14421] read(26, "p-rr", 4)         = 4
[pid 14421] read(26, "dd-p", 4)         = 4
[pid 14421] read(26, "lugi", 4)         = 4
[pid 14421] read(26, "ns/x", 4)         = 4
[pid 14421] read(26, "cp-r", 4)         = 4
[pid 14421] read(26, "rdd-", 4)         = 4
[pid 14421] read(26, "iost", 4)         = 4
[pid 14421] read(26, "at\r\n", 4)       = 4
[pid 14421] read(26, "\r\n", 2)         = 2
```

vs
```
[pid   705] read(27,  <unfinished ...>
[pid   705] <... read resumed> "P", 1)  = 1
[pid   705] read(27,  <unfinished ...>
[pid   705] <... read resumed> "O", 1)  = 1
[pid   705] read(27,  <unfinished ...>
[pid   705] <... read resumed> "S", 1)  = 1
[pid   705] read(27,  <unfinished ...>
[pid   705] <... read resumed> "T", 1)  = 1
[pid   705] read(27,  <unfinished ...>
[pid   705] <... read resumed> " ", 1)  = 1
[pid   705] read(27,  <unfinished ...>
[pid   705] <... read resumed> "/", 1)  = 1
[pid   705] read(27,  <unfinished ...>
[pid   705] <... read resumed> "v", 1)  = 1
[pid   705] read(27,  <unfinished ...>
[pid   705] <... read resumed> "a", 1)  = 1
[pid   705] read(27,  <unfinished ...>
[pid   705] <... read resumed> "r", 1)  = 1
[pid   705] read(27,  <unfinished ...>
[pid   705] <... read resumed> "/", 1)  = 1
...
```

This may not be enough to fix the performance problem, but should be an improvement.