### PR TITLE
CA-322045: do not spam the logs with errors about the 'tap-%d-%d' plugins

### DIFF
--- a/rrdd/rrdd_server.ml
+++ b/rrdd/rrdd_server.ml
@@ -438,10 +438,11 @@ module Plugin = struct
       let skip_max  = 256 in (* about 21.3 min on 5sec cycle *)
       Mutex.execute registered_m (fun () ->
           let skips     = min (plugin.skip_init * 2) skip_max in
-          warn "setting skip-cycles-after-error for plugin %s to %d"
-            (P.string_of_uid ~uid) skips;
           plugin.skip_init <- skips;
-          plugin.skip      <- skips)
+          plugin.skip      <- skips;
+          skips)
+      |> debug "setting skip-cycles-after-error for plugin %s to %d"
+        (P.string_of_uid ~uid)
 
     (* success - set skip to 0, reset initial value *)
     let reset_skip_count uid plugin =
@@ -471,7 +472,7 @@ module Plugin = struct
       | e ->
         incr_skip_count uid plugin; (* increase skip count *)
         let log e =
-          warn "Failed to process plugin: %s (%s)"
+          info "Failed to process plugin: %s (%s)"
             (P.string_of_uid ~uid)
             (Printexc.to_string e);
           log_backtrace ()

--- a/rrdd/rrdd_server.ml
+++ b/rrdd/rrdd_server.ml
@@ -472,7 +472,7 @@ module Plugin = struct
       | e ->
         incr_skip_count uid plugin; (* increase skip count *)
         let log e =
-          info "Failed to process plugin: %s (%s)"
+          info "Failed to process plugin metrics file: %s (%s)"
             (P.string_of_uid ~uid)
             (Printexc.to_string e);
           log_backtrace ()

--- a/rrdd/xcp_rrdd.ml
+++ b/rrdd/xcp_rrdd.ml
@@ -589,7 +589,10 @@ module Discover: DISCOVER = struct
   (** [is_valid f] is true, if [f] is a filename for an RRD file.
    *  Currently we only ignore *.tmp files *)
   let is_valid files_to_ignore file =
-     not @@ List.mem file files_to_ignore && not @@ Filename.check_suffix file ".tmp"
+     not @@ List.mem file files_to_ignore
+     && not @@ Filename.check_suffix file ".tmp"
+     (* the tap- files are not valid RRDs and spam the logs *)
+     && not @@ Astring.String.is_prefix ~affix:"tap-" file
 
   let events_as_string
     : Inotify.event_kind list -> string


### PR DESCRIPTION
These are files in `/dev/shm/metrics` created by tapdisk, but they are not in the right format.
We actually use xcp-rrdp-iostat which looks for metrics in `/dev/shm/td*` instead, so avoid spamming the logs.

@lippirk this might be useful for the issue you are working on too.

Also there was a place where we logged these messages while holding a lock, it should be safe to log this outside the lock.