### PR TITLE
CA-322045: backport

### DIFF
--- a/rrdd/rrdd_server.ml
+++ b/rrdd/rrdd_server.ml
@@ -474,9 +474,9 @@ module Plugin = struct
 			| e ->
 					incr_skip_count uid plugin; (* increase skip count *)
 				let log e =
-					warn "Failed to process plugin: %s (%s)"
-						(P.string_of_uid uid)
-						(Printexc.to_string e);
+					info "Failed to process plugin metrics file: %s (%s)"
+					  (P.string_of_uid uid)
+					  (Printexc.to_string e);
 					log_backtrace ()
 				in
 				let open Rrd_protocol in

--- a/rrdd/xcp_rrdd.ml
+++ b/rrdd/xcp_rrdd.ml
@@ -586,6 +586,8 @@ module Discover: DISCOVER = struct
 	 *  Currently we only ignore *.tmp files *)
 	let is_valid file =
 		not @@ Filename.check_suffix file ".tmp"
+		(* the tap- files are not valid RRDs and spam the logs *)
+		&& not @@ Xstringext.String.startswith "tap-" file
 
 	let events_as_string
 		: Inotify.event_kind list -> string

--- a/rrdd/xcp_rrdd.ml
+++ b/rrdd/xcp_rrdd.ml
@@ -66,6 +66,7 @@ let accept_forever sock f =
 (* Bind server to the file descriptor. *)
 let start (xmlrpc_path, http_fwd_path) process =
 	let server = Http_svr.Server.empty () in
+	Http_svr.Server.enable_fastpath server;
 	let open Rrdd_http_handler in
 	Http_svr.Server.add_handler server Http.Post "/" (Http_svr.BufIO (xmlrpc_handler process));
 	Http_svr.Server.add_handler server Http.Get Constants.get_vm_rrd_uri (Http_svr.FdIO get_vm_rrd_handler);


### PR DESCRIPTION
Had to use Xstringext instead of Astring (astring is present but would require updating the _oasis file which would regenerate setup.ml containing a lot of changes) to make backport simpler.