### PR TITLE
CA-325582: remove unused Host datasources to avoid space leaks

### DIFF
--- a/rrdd/rrdd_server.ml
+++ b/rrdd/rrdd_server.ml
@@ -67,8 +67,8 @@ let archive_rrd vm_uuid remote_address : unit =
   Mutex.execute mutex (fun () ->
       try
         let rrd = (Hashtbl.find vm_rrds vm_uuid).rrd in
+        Hashtbl.remove vm_rrds vm_uuid;
         archive_rrd_internal ~remote_address ~uuid:vm_uuid ~rrd ();
-        Hashtbl.remove vm_rrds vm_uuid
       with Not_found -> ())
 
 let backup_rrds (remote_address : string option) () : unit =

--- a/rrdd/rrdd_server.ml
+++ b/rrdd/rrdd_server.ml
@@ -26,7 +26,10 @@ open D
 
 let archive_sr_rrd (sr_uuid : string) : string =
   let sr_rrd = Mutex.execute mutex (fun () ->
-      try (Hashtbl.find sr_rrds sr_uuid)
+      try
+        let rrd = Hashtbl.find sr_rrds sr_uuid in
+        Hashtbl.remove sr_rrds sr_uuid;
+        rrd
       with Not_found ->
         let msg = Printf.sprintf "No RRD found for SR: %s." sr_uuid in
         raise (Rrdd_error (Archive_failed(msg)))


### PR DESCRIPTION
This needs to be deployed with corresponding commit in rrdd-plugins.

Previously we always kept all datasources we've ever seen for a host
even if we temporarily stopped receiving RRD updates for it.
This is useful for per-host SR-level RRDs which only exist when at least
one VM using it is running: we want to see the historic data when the VM
is started again.
However if SRs are attached/detached frequently this can cause xcp-rrdd
to increase in memory usage over time, even across toolstack restarts or
host reboots, because all host-level RRDs were preserved.
This was not visible in `xe host-data-source-list`, since that lists
only the active RRDs.

Solution is to preserve only the latest reported RRDs for hosts, and to
ask plugins to keep reporting data for inactive RRDs that they need.
E.g. rrdp-iostat should keep reporting data for SRs that have a PBD for
that host, even if no VM is using it or the PBD is temporarily
unplugged.

Corressponding change in rrdp-iostat is WiP.