### PR TITLE
CA-325582: Report disabled datasources

### DIFF
--- a/rrdd/rrdd_server.ml
+++ b/rrdd/rrdd_server.ml
@@ -67,8 +67,8 @@ let archive_rrd vm_uuid remote_address : unit =
   Mutex.execute mutex (fun () ->
       try
         let rrd = (Hashtbl.find vm_rrds vm_uuid).rrd in
+        Hashtbl.remove vm_rrds vm_uuid;
         archive_rrd_internal ~remote_address ~uuid:vm_uuid ~rrd ();
-        Hashtbl.remove vm_rrds vm_uuid
       with Not_found -> ())
 
 let backup_rrds (remote_address : string option) () : unit =

--- a/rrdd/rrdd_server.ml
+++ b/rrdd/rrdd_server.ml
@@ -26,7 +26,10 @@ open D
 
 let archive_sr_rrd (sr_uuid : string) : string =
   let sr_rrd = Mutex.execute mutex (fun () ->
-      try (Hashtbl.find sr_rrds sr_uuid)
+      try
+        let rrd = Hashtbl.find sr_rrds sr_uuid in
+        Hashtbl.remove sr_rrds sr_uuid;
+        rrd
       with Not_found ->
         let msg = Printf.sprintf "No RRD found for SR: %s." sr_uuid in
         raise (Rrdd_error (Archive_failed(msg)))


### PR DESCRIPTION
Previously only active (enabled) datasources were being exposed through the API. This means that now xen-api has visibility all default datasources, which translate in all datasources in practice.

This is necessary for xapi to clean up datasources when destroying SRs.

Unfortunately inactive sources do not have available neither the metrics nor the description. This is because there are 3 "datasource" types scattered in the system, 2 of them in the same data structure in xcp-rrdd. I think it would be beneficial if these were consolidated somehow to remove duplication.

From the 3 commits, only one is needed to report disabled datasources, the other two help keep the memory consumption down.