### PR TITLE
CA-325582: Report disabled sources

### DIFF
--- a/rrdd/rrdd_server.ml
+++ b/rrdd/rrdd_server.ml
@@ -275,18 +275,33 @@ let forget_host_ds _ ~(ds_name : string) : unit =
 	)
 
 let query_possible_dss rrdi =
-	let enabled_dss = Rrd.ds_names rrdi.rrd in
-	let open Ds in
-	let open Data_source in
-	List.map (fun ds -> {
-		name = ds.ds_name;
-		description = ds.ds_description;
-		enabled = List.mem ds.ds_name enabled_dss;
-		standard = ds.ds_default;
-		min = ds.ds_min;
-		max = ds.ds_max;
-		units = ds.ds_units;
-	}) rrdi.dss
+  let module SMap = Map.Make(String) in
+  let enabled_sources = rrdi.dss
+  |> List.fold_left (fun acc ds -> SMap.add ds.Ds.ds_name ds acc) SMap.empty
+  in
+  rrdi.rrd.Rrd.rrd_dss (* these are all data sources available to the daemon *)
+  |> Array.map (fun ds ->
+    let enabled_source = try
+        Some (SMap.find ds.Rrd.ds_name enabled_sources)
+      with Not_found ->
+        None
+    in
+    let description, standard, units = match enabled_source with
+    | Some source ->
+      source.Ds.ds_description, source.Ds.ds_default, source.ds_units
+    | None ->
+      "description not available", false, "unknown"
+    in
+  let open Data_source in
+    { name = ds.ds_name
+    ; description
+    ; enabled = enabled_source != None
+    ; standard
+    ; min = ds.ds_min
+    ; max = ds.ds_max
+    ; units
+    })
+  |> Array.to_list
 
 let query_possible_host_dss _ () : Data_source.t list =
 	Mutex.execute mutex (fun () ->


### PR DESCRIPTION
Previously they weren't being reported at all, which made it impossible
for xapi to have visibility on them

Cherry-picked with modifications from 46219b8ae6001aefb01352c41288c5499801e74e

The modifications were needed because the Map functions that were used ere too modern and the stdext libraries changed. Untested