### PR TITLE
CA-325582 Report disabled data sources (backport to 7.1 CU2)

### DIFF
--- a/rrdd/rrdd_server.ml
+++ b/rrdd/rrdd_server.ml
@@ -275,18 +275,64 @@ let forget_host_ds _ ~(ds_name : string) : unit =
 	)
 
 let query_possible_dss rrdi =
-	let enabled_dss = Rrd.ds_names rrdi.rrd in
-	let open Ds in
-	let open Data_source in
-	List.map (fun ds -> {
-		name = ds.ds_name;
-		description = ds.ds_description;
-		enabled = List.mem ds.ds_name enabled_dss;
-		standard = ds.ds_default;
-		min = ds.ds_min;
-		max = ds.ds_max;
-		units = ds.ds_units;
-	}) rrdi.dss
+  (* We have data sources coming from different places, so we want the union of these;
+     this happens to be the union of the rrdi.rrd (live) and rrdi.rrd.rdd_dss (archival).
+     This is straighforward, but those two sets of ds have different types,
+     hence we need to coerce them into a common type (this is why we have
+     'description not available', and 'units unknown' etc.).
+     Deciding whether a ds is enabled is also not obvious. If we have a 'live'
+     ds, then it is enabled if it exists in the set rrdi.rrd. If we have an 'archival'
+     ds, then it is enabled if it is also an enabled 'live' ds, otherwise it is
+     disabled.
+   *)
+  let module SSet = Set.Make(String) in
+  let module SMap = Map.Make(String) in
+  let open Ds in
+  let open Data_source in
+
+  let live_sources = rrdi.dss in
+  let archival_sources = rrdi.rrd.rrd_dss in
+
+  let name_to_live_dss =
+    let enabled_names = Rrd.ds_names rrdi.rrd |> SSet.of_list in
+    let is_live_ds_enabled ds = SSet.mem ds.ds_name enabled_names in
+    live_sources |>
+    List.fold_left (fun map ds ->
+      let k = ds.ds_name in
+      let v = { name = ds.ds_name
+              ; description = ds.ds_description
+              ; enabled = is_live_ds_enabled ds
+              ; standard = ds.ds_default
+              ; min= ds.ds_min
+              ; max = ds.ds_max
+              ; units = ds.ds_units
+              }
+      in
+      SMap.add k v map) SMap.empty
+  in
+  let name_to_live_and_archival_dss =
+    let add_source_if_missing m ds =
+      if SMap.mem ds.Rrd.ds_name m then
+        m
+      else
+        let k = ds.ds_name in
+        let v = { name = ds.ds_name
+                ; description = "description not available"
+                ; enabled = false
+                ; standard = false
+                ; units = "unknown"
+                ; min = ds.ds_min
+                ; max = ds.ds_max
+                }
+        in
+        SMap.add k v m
+    in
+    Array.fold_left add_source_if_missing name_to_live_dss archival_sources
+  in
+  name_to_live_and_archival_dss |>
+  SMap.bindings |>
+  List.map snd
+
 
 let query_possible_host_dss _ () : Data_source.t list =
 	Mutex.execute mutex (fun () ->


### PR DESCRIPTION
Previously they weren't being reported at all, which made it impossible
for xapi to have visibility on them.

(This is a combination of 46219b8
and b0af2ca. There was a bug with
the former, which is fixed by the latter. Only the latter is
cherry-picked to avoid extra work.)

Signed-off-by: lippirk <ben.anson@citrix.com>
(cherry picked from commit b0af2ca)