### PR TITLE
CP-36100 REQ-403 add verify_cert parameter to SSL make calls

### DIFF
--- a/bin/rrdd/rrdd_server.ml
+++ b/bin/rrdd/rrdd_server.ml
@@ -150,7 +150,7 @@ module Deprecated = struct
     in
     let open Xmlrpc_client in
     let transport =
-      SSL (SSL.make (), master_address, !Rrdd_shared.https_port)
+      SSL (SSL.make ~verify_cert:(Stunnel_client.pool ()) (), master_address, !Rrdd_shared.https_port)
     in
     with_transport transport
       (with_http request (fun (response, s) ->

--- a/bin/rrdd/rrdd_shared.ml
+++ b/bin/rrdd/rrdd_shared.ml
@@ -124,7 +124,7 @@ let send_rrd ?(session_id : string option) ~(address : string)
       ~cookie Http.Put Rrdd_libs.Constants.put_rrd_uri
   in
   let open Xmlrpc_client in
-  let transport = SSL (SSL.make (), address, !https_port) in
+  let transport = SSL (SSL.make ~verify_cert:None (), address, !https_port) in
   with_transport transport
     (with_http request (fun (_response, fd) ->
          try Rrd_unix.to_fd rrd fd with _ -> log_backtrace ())) ;


### PR DESCRIPTION
We use a placeholder of None in the send_rrd function. This should be
changed later to use the special migration trust bundle.