### PR TITLE
CP-36100: verify remote host on rrd backup and archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,4 +43,4 @@ format:
 verify-cert:
 	@NONE=$$( git grep -r --count 'verify_cert:None' -- **/*.ml | cut -d ':' -f 2 | paste -sd+ - | bc) ;\
 	echo "counted $$NONE usages of verify_cert:None" ;\
-	test $$NONE -eq 3
+	test $$NONE -eq 1


### PR DESCRIPTION
They are used for sending rrds to the pool master exclusively by xapi,
and it has no way to send them to any other host. Connecting to hosts
outside of the pool and verification must fail in these cases.

This deductions were done thanks to https://github.com/xapi-project/xen-api/pull/4358