### PR TITLE
Backport: CA-371780: Port xcp-rrdd tests to alcotest, Reduce overheads in update_rrdds

### DIFF
--- a/rrdd/rrdd_monitor.ml
+++ b/rrdd/rrdd_monitor.ml
@@ -50,9 +50,11 @@ let create_fresh_rrd use_min_max dss =
 let merge_new_dss rrd dss =
   let should_enable_ds ds = !Rrdd_shared.enable_all_dss || ds.ds_default in
   let enabled_dss = List.filter should_enable_ds dss in
-  let current_dss = Rrd.ds_names rrd in
+  let current_dss = Rrd.ds_names rrd |> StringSet.of_list in
   let new_dss =
-    List.filter (fun ds -> not (List.mem ds.ds_name current_dss)) enabled_dss
+    List.filter
+      (fun ds -> not (StringSet.mem ds.ds_name current_dss))
+      enabled_dss
   in
   let now = Unix.gettimeofday () in
   List.fold_left

--- a/rrdd/rrdd_monitor.ml
+++ b/rrdd/rrdd_monitor.ml
@@ -62,6 +62,29 @@ let merge_new_dss rrd dss =
     )
     rrd new_dss
 
+module OwnerMap = Map.Make (struct
+  type t = ds_owner
+
+  let compare a b =
+    match (a, b) with
+    | Host, Host ->
+        0
+    | Host, _ | VM _, SR _ ->
+        -1
+    | _, Host | SR _, VM _ ->
+        1
+    | VM a, VM b | SR a, SR b ->
+        String.compare a b
+end)
+
+let owner_to_string () = function
+  | Host ->
+      "host"
+  | VM uuid ->
+      "VM " ^ uuid
+  | SR uuid ->
+      "SR " ^ uuid
+
 (** Updates all of the hosts rrds. We are passed a list of uuids that is used as
     the primary source for which VMs are resident on us. When a new uuid turns
     up that we haven't got an RRD for in our hashtbl, we create a new one. When
@@ -69,7 +92,28 @@ let merge_new_dss rrd dss =
     update, we assume that the domain has gone and we stream the RRD to the
     master. We also have a list of the currently rebooting VMs to ensure we
     don't accidentally archive the RRD. *)
-let update_rrds timestamp dss (uuid_domids : (string * int) list) paused_vms =
+let update_rrds timestamp dss uuid_domids paused_vms =
+  let uuid_domids = List.to_seq uuid_domids |> StringMap.of_seq in
+  let paused_vms = List.to_seq paused_vms |> StringSet.of_seq in
+  let consolidate all (owner, ds) =
+    let add_ds_to = StringMap.add ds.ds_name ds in
+    let merge = function
+      | None ->
+          Some (add_ds_to StringMap.empty)
+      | Some dss ->
+          warn {|%s: found duplicate datasource with key "%s" in owner "%a"|}
+            __FUNCTION__ ds.ds_name owner_to_string owner ;
+          Some (add_ds_to dss)
+    in
+    OwnerMap.update owner merge all
+  in
+  let dss = List.fold_left consolidate OwnerMap.empty dss in
+
+  (* the first parameter and ds.ds_name are equivalent *)
+  let to_named_updates (_, ds) =
+    (ds.ds_name, (ds.ds_value, ds.ds_pdp_transform_function))
+  in
+
   (* Here we do the synchronising between the dom0 view of the world and our
      Hashtbl. By the end of this execute block, the Hashtbl correctly represents
      the world *)
@@ -89,19 +133,14 @@ let update_rrds timestamp dss (uuid_domids : (string * int) list) paused_vms =
           "Clock just went backwards by %.0f seconds: RRD data may now be \
            unreliable"
           by_how_much ;
-      let do_vm (vm_uuid, domid) =
+      let process_vm vm_uuid dss =
+        let named_updates =
+          StringMap.to_seq dss |> Seq.map to_named_updates |> List.of_seq
+        in
+        let dss = StringMap.to_seq dss |> Seq.map snd |> List.of_seq in
+
         try
-          let dss =
-            List.filter_map
-              (fun (ty, ds) ->
-                match ty with
-                | VM x ->
-                    if x = vm_uuid then Some ds else None
-                | _ ->
-                    None
-              )
-              dss
-          in
+          let domid = StringMap.find vm_uuid uuid_domids in
           (* First, potentially update the rrd with any new default dss *)
           try
             let rrdi = Hashtbl.find vm_rrds vm_uuid in
@@ -111,89 +150,70 @@ let update_rrds timestamp dss (uuid_domids : (string * int) list) paused_vms =
                purpose. During a migrate such updates can also cause undesirable
                discontinuities in the observed value of memory_actual. Hence, we
                ignore changes from paused domains: *)
-            if not (List.mem vm_uuid paused_vms) then (
+            if not (StringSet.mem vm_uuid paused_vms) then (
               Rrd.ds_update_named rrd timestamp ~new_domid:(domid <> rrdi.domid)
-                (List.map
-                   (fun ds ->
-                     (ds.ds_name, (ds.ds_value, ds.ds_pdp_transform_function))
-                   )
-                   dss
-                ) ;
+                named_updates ;
               rrdi.dss <- dss ;
               rrdi.domid <- domid
             )
           with
           | Not_found ->
-              debug "Creating fresh RRD for VM uuid=%s" vm_uuid ;
+              debug "%s: Creating fresh RRD for VM uuid=%s" __FUNCTION__ vm_uuid ;
               let rrd = create_fresh_rrd !use_min_max dss in
               Hashtbl.replace vm_rrds vm_uuid {rrd; dss; domid}
           | e ->
               raise e
         with _ -> log_backtrace ()
       in
-      List.iter do_vm uuid_domids ;
-      let do_sr sr_uuid =
+      let process_sr sr_uuid dss =
+        let named_updates =
+          StringMap.to_seq dss |> Seq.map to_named_updates |> List.of_seq
+        in
+        let dss = StringMap.to_seq dss |> Seq.map snd |> List.of_seq in
         try
-          let dss =
-            List.filter_map
-              (fun (ty, ds) ->
-                match ty with
-                | SR x ->
-                    if x = sr_uuid then Some ds else None
-                | _ ->
-                    None
-              )
-              dss
-          in
           (* First, potentially update the rrd with any new default dss *)
           try
             let rrdi = Hashtbl.find sr_rrds sr_uuid in
             let rrd = merge_new_dss rrdi.rrd dss in
             Hashtbl.replace sr_rrds sr_uuid {rrd; dss; domid= 0} ;
-            Rrd.ds_update_named rrd timestamp ~new_domid:false
-              (List.map
-                 (fun ds ->
-                   (ds.ds_name, (ds.ds_value, ds.ds_pdp_transform_function))
-                 )
-                 dss
-              ) ;
+            Rrd.ds_update_named rrd timestamp ~new_domid:false named_updates ;
             rrdi.dss <- dss ;
             rrdi.domid <- 0
           with
           | Not_found ->
-              debug "Creating fresh RRD for SR uuid=%s" sr_uuid ;
+              debug "%s: Creating fresh RRD for SR uuid=%s" __FUNCTION__ sr_uuid ;
               let rrd = create_fresh_rrd !use_min_max dss in
               Hashtbl.replace sr_rrds sr_uuid {rrd; dss; domid= 0}
           | e ->
               raise e
         with _ -> log_backtrace ()
       in
-      List.to_seq dss
-      |> Seq.filter_map (fun (ty, _ds) ->
-             match ty with SR x -> Some x | _ -> None
-         )
-      |> StringSet.of_seq
-      |> StringSet.iter do_sr ;
-      let host_dss =
-        List.filter_map
-          (fun (ty, ds) -> match ty with Host -> Some ds | _ -> None)
-          dss
+      let process_host dss =
+        let named_updates =
+          StringMap.to_seq dss |> Seq.map to_named_updates |> List.of_seq
+        in
+        let dss = StringMap.to_seq dss |> Seq.map snd |> List.of_seq in
+
+        match !host_rrd with
+        | None ->
+            debug "%s: Creating fresh RRD for localhost" __FUNCTION__ ;
+            let rrd = create_fresh_rrd true dss in
+            (* Always always create localhost rrds with min/max enabled *)
+            host_rrd := Some {rrd; dss; domid= 0}
+        | Some rrdi ->
+            rrdi.dss <- dss ;
+            let rrd = merge_new_dss rrdi.rrd dss in
+            host_rrd := Some {rrd; dss; domid= 0} ;
+            Rrd.ds_update_named rrd timestamp ~new_domid:false named_updates
       in
-      match !host_rrd with
-      | None ->
-          debug "Creating fresh RRD for localhost" ;
-          let rrd = create_fresh_rrd true host_dss in
-          (* Always always create localhost rrds with min/max enabled *)
-          host_rrd := Some {rrd; dss= host_dss; domid= 0}
-      | Some rrdi ->
-          rrdi.dss <- host_dss ;
-          let rrd = merge_new_dss rrdi.rrd host_dss in
-          host_rrd := Some {rrd; dss= host_dss; domid= 0} ;
-          Rrd.ds_update_named rrd timestamp ~new_domid:false
-            (List.map
-               (fun ds ->
-                 (ds.ds_name, (ds.ds_value, ds.ds_pdp_transform_function))
-               )
-               host_dss
-            )
+      let process_dss ds_owner dss =
+        match ds_owner with
+        | Host ->
+            process_host dss
+        | VM uuid ->
+            process_vm uuid dss
+        | SR uuid ->
+            process_sr uuid dss
+      in
+      OwnerMap.iter process_dss dss
   )

--- a/rrdd/rrdd_monitor.ml
+++ b/rrdd/rrdd_monitor.ml
@@ -85,6 +85,8 @@ let owner_to_string () = function
   | SR uuid ->
       "SR " ^ uuid
 
+module StringMap = Map.Make (String)
+
 (** Updates all of the hosts rrds. We are passed a list of uuids that is used as
     the primary source for which VMs are resident on us. When a new uuid turns
     up that we haven't got an RRD for in our hashtbl, we create a new one. When
@@ -93,6 +95,7 @@ let owner_to_string () = function
     master. We also have a list of the currently rebooting VMs to ensure we
     don't accidentally archive the RRD. *)
 let update_rrds timestamp dss uuid_domids paused_vms =
+  let __FUNCTION__ = "Rrdd_monitor.update_rrds" in
   let uuid_domids = List.to_seq uuid_domids |> StringMap.of_seq in
   let paused_vms = List.to_seq paused_vms |> StringSet.of_seq in
   let consolidate all (owner, ds) =
@@ -101,8 +104,6 @@ let update_rrds timestamp dss uuid_domids paused_vms =
       | None ->
           Some (add_ds_to StringMap.empty)
       | Some dss ->
-          warn {|%s: found duplicate datasource with key "%s" in owner "%a"|}
-            __FUNCTION__ ds.ds_name owner_to_string owner ;
           Some (add_ds_to dss)
     in
     OwnerMap.update owner merge all

--- a/test/dune
+++ b/test/dune
@@ -1,15 +1,12 @@
-
-(executable
+(test
   (name test_rrdd_monitor)
+  (package xapi-rrdd)
   (libraries
-    oUnit
+    alcotest
     rrdd_libs_internal
+    xapi-idl.rrd
+    xapi-rrd
   )
   (preprocess (pps ppx_deriving_rpc))
 )
 
-(alias
-  (name runtest)
-  (deps (:x test_rrdd_monitor.exe))
-  (action (run %{x}))
-)

--- a/test/test_rrdd_monitor.ml
+++ b/test/test_rrdd_monitor.ml
@@ -31,8 +31,10 @@ let dss_of_rrds rrds =
 
 let check_datasources kind rdds expected_dss =
   match rdds with
-  | None ->
+  | None when expected_dss <> [] ->
       Alcotest.fail (Printf.sprintf "%s RRD must be created" kind)
+  | None ->
+      ()
   | Some actual_rdds ->
       let actual_dss = dss_of_rrds actual_rdds in
       let expected_dss = List.fast_sort Stdlib.compare expected_dss in

--- a/test/test_rrdd_monitor.ml
+++ b/test/test_rrdd_monitor.ml
@@ -1,7 +1,3 @@
-open OUnit2
-
-let assert_equal_int = assert_equal ~printer:string_of_int
-
 let ds_a =
   Ds.ds_make ~name:"ds_a" ~units:"(fraction)" ~description:"datasource a"
     ~value:(Rrd.VT_Float 1.0) ~ty:Rrd.Gauge ~default:true ()
@@ -10,94 +6,113 @@ let ds_b =
   Ds.ds_make ~name:"ds_b" ~units:"(fraction)" ~description:"datasource b"
     ~value:(Rrd.VT_Float 2.0) ~ty:Rrd.Gauge ~default:true ()
 
-let reset_rrdd_shared_state _ctxt =
+let reset_rrdd_shared_state () =
   Hashtbl.clear Rrdd_shared.vm_rrds ;
   Rrdd_shared.host_rrd := None
 
-let dump_dss = List.map (fun ds -> ds.Ds.ds_name)
+let pp_ds =
+  Fmt.(
+    Dump.record
+      [
+        Dump.field "ds_name" (fun t -> t.Ds.ds_name) string
+      ; Dump.field "ds_description" (fun t -> t.Ds.ds_description) string
+      ; Dump.field "ds_default" (fun t -> t.Ds.ds_default) bool
+      ; Dump.field "ds_min" (fun t -> t.Ds.ds_min) float
+      ; Dump.field "ds_max" (fun t -> t.Ds.ds_max) float
+      ; Dump.field "ds_units" (fun t -> t.Ds.ds_units) string
+      ]
+  )
 
-let dump_rrd_hash hash =
-  Hashtbl.fold (fun k v acc -> (k, dump_dss v.Rrdd_shared.dss) :: acc) hash []
+let ds = Alcotest.testable pp_ds (fun a b -> String.equal a.ds_name b.ds_name)
 
-let string_of_rrd_dump dump =
-  let rrds =
-    List.map
-      (fun (k, v) -> Printf.sprintf "(%s, [%s])" k (String.concat "; " v))
-      dump
-  in
-  Printf.sprintf "[%s]" (String.concat "; " rrds)
+let dss_of_rrds rrds =
+  Hashtbl.fold (fun k v acc -> (k, v.Rrdd_shared.dss) :: acc) rrds []
+  |> List.fast_sort Stdlib.compare
 
-let check_rrd_hash actual_rrds expected_rrds =
-  assert_equal ~printer:string_of_rrd_dump
-    (List.sort compare expected_rrds)
-    (List.sort compare (dump_rrd_hash actual_rrds))
-
-let check_host_dss expected_dss =
-  match !Rrdd_shared.host_rrd with
+let check_datasources kind rdds expected_dss =
+  match rdds with
   | None ->
-      assert_failure "host_rrd should have been created"
-  | Some info ->
-      assert_equal ~printer:(String.concat "; ")
-        (List.sort compare expected_dss)
-        (List.sort compare (dump_dss info.Rrdd_shared.dss))
+      Alcotest.fail (Printf.sprintf "%s RRD must be created" kind)
+  | Some actual_rdds ->
+      let actual_dss = dss_of_rrds actual_rdds in
+      let expected_dss = List.fast_sort Stdlib.compare expected_dss in
+      Alcotest.(check @@ list @@ pair string (list ds))
+        (Printf.sprintf "%s rrds are not expected" kind)
+        actual_dss expected_dss
+
+let host_rrds rrd_info =
+  Option.bind rrd_info @@ fun rrd_info ->
+  let h = Hashtbl.create 1 in
+  if rrd_info.Rrdd_shared.dss <> [] then
+    Hashtbl.add h "host" rrd_info ;
+  Some h
 
 let update_rrds_test ~dss ~uuid_domids ~paused_vms ~expected_vm_rrds
-    ~expected_sr_rrds ~expected_host_dss ctxt =
-  OUnit2.bracket reset_rrdd_shared_state (fun () -> ignore) ctxt ;
-  Rrdd_monitor.update_rrds 12345.0 dss uuid_domids paused_vms ;
-  check_rrd_hash Rrdd_shared.vm_rrds expected_vm_rrds ;
-  check_rrd_hash Rrdd_shared.sr_rrds expected_sr_rrds ;
-  check_host_dss expected_host_dss
+    ~expected_sr_rrds ~expected_host_dss =
+  let test () =
+    reset_rrdd_shared_state () ;
+    Rrdd_monitor.update_rrds 12345.0 dss uuid_domids paused_vms ;
+    check_datasources "VM" (Some Rrdd_shared.vm_rrds) expected_vm_rrds ;
+    check_datasources "SR" (Some Rrdd_shared.sr_rrds) expected_sr_rrds ;
+    check_datasources "Host" (host_rrds !Rrdd_shared.host_rrd) expected_host_dss
+  in
+  [("", `Quick, test)]
 
 let update_rrds =
-  "update_rrds"
-  >:::
   let open Rrd in
   [
-    "Null update"
-    >:: update_rrds_test ~dss:[] ~uuid_domids:[] ~paused_vms:[]
-          ~expected_vm_rrds:[] ~expected_sr_rrds:[] ~expected_host_dss:[]
-  ; "Single host update"
-    >:: update_rrds_test ~dss:[(Host, ds_a)] ~uuid_domids:[] ~paused_vms:[]
-          ~expected_vm_rrds:[] ~expected_sr_rrds:[] ~expected_host_dss:["ds_a"]
-  ; "Multiple host updates"
-    >:: update_rrds_test
-          ~dss:[(Host, ds_a); (Host, ds_a)]
-          ~uuid_domids:[] ~paused_vms:[] ~expected_vm_rrds:[]
-          ~expected_sr_rrds:[] ~expected_host_dss:["ds_a"; "ds_a"]
-  ; "Single non-resident VM update"
-    >:: update_rrds_test ~dss:[(VM "a", ds_a)] ~uuid_domids:[] ~paused_vms:[]
-          ~expected_vm_rrds:[] ~expected_sr_rrds:[] ~expected_host_dss:[]
-  ; "Multiple non-resident VM updates"
-    >:: update_rrds_test
-          ~dss:[(VM "a", ds_a); (VM "b", ds_a)]
-          ~uuid_domids:[] ~paused_vms:[] ~expected_vm_rrds:[]
-          ~expected_sr_rrds:[] ~expected_host_dss:[]
-  ; "Single resident VM update"
-    >:: update_rrds_test ~dss:[(VM "a", ds_a)] ~uuid_domids:[("a", 1)]
-          ~paused_vms:[]
-          ~expected_vm_rrds:[("a", ["ds_a"])]
-          ~expected_sr_rrds:[] ~expected_host_dss:[]
-  ; "Multiple resident VM updates"
-    >:: update_rrds_test
-          ~dss:[(VM "a", ds_a); (VM "b", ds_a); (VM "b", ds_b)]
-          ~uuid_domids:[("a", 1); ("b", 1)] ~paused_vms:[]
-          ~expected_vm_rrds:[("a", ["ds_a"]); ("b", ["ds_a"; "ds_b"])]
-          ~expected_sr_rrds:[] ~expected_host_dss:[]
-  ; "Multiple resident and non-resident VM updates"
-    >:: update_rrds_test
-          ~dss:[(VM "a", ds_a); (VM "b", ds_a); (VM "c", ds_a)]
-          ~uuid_domids:[("a", 1); ("b", 1)] ~paused_vms:[]
-          ~expected_vm_rrds:[("a", ["ds_a"]); ("b", ["ds_a"])]
-          ~expected_sr_rrds:[] ~expected_host_dss:[]
-  ; "Multiple SR updates"
-    >:: update_rrds_test
-          ~dss:[(SR "a", ds_a); (SR "b", ds_a); (SR "b", ds_b)]
-          ~uuid_domids:[] ~paused_vms:[] ~expected_vm_rrds:[]
-          ~expected_sr_rrds:[("a", ["ds_a"]); ("b", ["ds_a"; "ds_b"])]
-          ~expected_host_dss:[]
+    ( "Null update"
+    , update_rrds_test ~dss:[] ~uuid_domids:[] ~paused_vms:[]
+        ~expected_vm_rrds:[] ~expected_sr_rrds:[] ~expected_host_dss:[]
+    )
+  ; ( "Single host update"
+    , update_rrds_test ~dss:[(Host, ds_a)] ~uuid_domids:[] ~paused_vms:[]
+        ~expected_vm_rrds:[] ~expected_sr_rrds:[]
+        ~expected_host_dss:[("host", [ds_a])]
+    )
+  ; ( "Multiple host updates"
+    , update_rrds_test
+        ~dss:[(Host, ds_a); (Host, ds_b)]
+        ~uuid_domids:[] ~paused_vms:[] ~expected_vm_rrds:[] ~expected_sr_rrds:[]
+        ~expected_host_dss:[("host", [ds_a; ds_b])]
+    )
+  ; ( "Single non-resident VM update"
+    , update_rrds_test ~dss:[(VM "a", ds_a)] ~uuid_domids:[] ~paused_vms:[]
+        ~expected_vm_rrds:[] ~expected_sr_rrds:[] ~expected_host_dss:[]
+    )
+  ; ( "Multiple non-resident VM updates"
+    , update_rrds_test
+        ~dss:[(VM "a", ds_a); (VM "b", ds_a)]
+        ~uuid_domids:[] ~paused_vms:[] ~expected_vm_rrds:[] ~expected_sr_rrds:[]
+        ~expected_host_dss:[]
+    )
+  ; ( "Single resident VM update"
+    , update_rrds_test ~dss:[(VM "a", ds_a)] ~uuid_domids:[("a", 1)]
+        ~paused_vms:[]
+        ~expected_vm_rrds:[("a", [ds_a])]
+        ~expected_sr_rrds:[] ~expected_host_dss:[]
+    )
+  ; ( "Multiple resident VM updates"
+    , update_rrds_test
+        ~dss:[(VM "a", ds_a); (VM "b", ds_a); (VM "b", ds_b)]
+        ~uuid_domids:[("a", 1); ("b", 1)] ~paused_vms:[]
+        ~expected_vm_rrds:[("a", [ds_a]); ("b", [ds_a; ds_b])]
+        ~expected_sr_rrds:[] ~expected_host_dss:[]
+    )
+  ; ( "Multiple resident and non-resident VM updates"
+    , update_rrds_test
+        ~dss:[(VM "a", ds_a); (VM "b", ds_a); (VM "c", ds_a)]
+        ~uuid_domids:[("a", 1); ("b", 1)] ~paused_vms:[]
+        ~expected_vm_rrds:[("a", [ds_a]); ("b", [ds_a])]
+        ~expected_sr_rrds:[] ~expected_host_dss:[]
+    )
+  ; ( "Multiple SR updates"
+    , update_rrds_test
+        ~dss:[(SR "a", ds_a); (SR "b", ds_a); (SR "b", ds_b)]
+        ~uuid_domids:[] ~paused_vms:[] ~expected_vm_rrds:[]
+        ~expected_sr_rrds:[("a", [ds_a]); ("b", [ds_a; ds_b])]
+        ~expected_host_dss:[]
+    )
   ]
 
-let suite = "rrdd monitor test" >::: [update_rrds]
-
-let () = run_test_tt_main suite
+let () = Alcotest.run "RRD daemon monitor test" update_rrds

--- a/xapi-rrdd.opam
+++ b/xapi-rrdd.opam
@@ -9,8 +9,8 @@ authors: "xen-api@lists.xen.org"
 homepage: "https://github.com/xapi-project/xcp-rrdd"
 bug-reports: "https://github.com/xapi-project/xcp-rrdd/issues"
 depends: [
-  "ocaml" {>= "4.02.0"}
-  "dune" {build}
+  "ocaml" {>= "4.07.0"}
+  "dune"
   "astring"
   "gzip"
   "http-svr"

--- a/xapi-rrdd.opam
+++ b/xapi-rrdd.opam
@@ -17,7 +17,7 @@ depends: [
   "inotify"
   "io-page"
   "mtime"
-  "ounit" {with-test}
+  "alcotest" {with-test}
   "ppx_deriving_rpc"
   "rpclib"
   "systemd"


### PR DESCRIPTION
Backport of https://github.com/xapi-project/xen-api/pull/4843

The dune file for the rrdd_monitor test is now the same as the latest version in xen-api (`executable` + `alias` stanzas was replaced by a single `test` one)

There were a couple of fixes to make it compile, and an additional change to remove logspam produced by a useless warning logline.